### PR TITLE
only the biggest unit update

### DIFF
--- a/lib/countdown.dart
+++ b/lib/countdown.dart
@@ -1,15 +1,20 @@
 class CountDown {
-  String timeLeft(DateTime due,
-      String finishedText,
-      String daysTextLong,
-      String hoursTextLong,
-      String minutesTextLong,
-      String secondsTextLong,
-      String daysTextShort,
-      String hoursTextShort,
-      String minutesTextShort,
-      String secondsTextShort,
-      {bool? longDateName, bool? showLabel}) {
+  String timeLeft(
+    DateTime due,
+    String finishedText,
+    String daysTextLong,
+    String hoursTextLong,
+    String minutesTextLong,
+    String secondsTextLong,
+    String daysTextShort,
+    String hoursTextShort,
+    String minutesTextShort,
+    String secondsTextShort, {
+    bool? longDateName,
+    bool? showLabel,
+    bool collapsing = false,
+    String endingText = ' left',
+  }) {
     String retVal = "";
 
     Duration _timeUntilDue = due.difference(DateTime.now());
@@ -26,7 +31,7 @@ class CountDown {
         : _secUntil.toString().substring(_secUntil.toString().length - 2);
 
     //Check whether to return longDateName date name or not
-    if (showLabel == false){
+    if (showLabel == false) {
       if (_daysUntil > 0) {
         retVal += _daysUntil.toString() + " : ";
       }
@@ -39,37 +44,40 @@ class CountDown {
       if (_secUntil > 0) {
         retVal += s;
       }
-    }else {
+    } else {
       if (longDateName == false) {
         if (_daysUntil > 0) {
           retVal += _daysUntil.toString() + daysTextShort;
         }
-        if (_hoursUntil > 0) {
+        if (_hoursUntil > 0 && (!collapsing || _daysUntil <= 0)) {
           retVal += _hoursUntil.toString() + hoursTextShort;
         }
-        if (_minUntil > 0) {
+        if (_minUntil > 0 && (!collapsing || _hoursUntil <= 0)) {
           retVal += _minUntil.toString() + minutesTextShort;
         }
-        if (_secUntil > 0) {
+        if (_secUntil > 0 && (!collapsing || _minUntil <= 0)) {
           retVal += s + secondsTextShort;
         }
       } else {
         if (_daysUntil > 0) {
           retVal += _daysUntil.toString() + daysTextLong;
         }
-        if (_hoursUntil > 0) {
+        if (_hoursUntil > 0 && (!collapsing || _daysUntil <= 0)) {
           retVal += _hoursUntil.toString() + hoursTextLong;
         }
-        if (_minUntil > 0) {
+        if (_minUntil > 0 && (!collapsing || _hoursUntil <= 0)) {
           retVal += _minUntil.toString() + minutesTextLong;
         }
-        if (_secUntil > 0) {
+        if (_secUntil > 0 && (!collapsing || _minUntil <= 0)) {
           retVal += s + secondsTextLong;
         }
       }
     }
-    if(_secUntil<1){
+    if (_secUntil < 1) {
       retVal = finishedText;
+    }
+    else if (collapsing) {
+      retVal += endingText;
     }
     return retVal;
   }

--- a/lib/countdown.dart
+++ b/lib/countdown.dart
@@ -73,7 +73,7 @@ class CountDown {
         }
       }
     }
-    if (_secUntil < 1) {
+    if (_timeUntilDue.inSeconds < 1) {
       retVal = finishedText;
     }
     else if (collapsing) {

--- a/lib/date_count_down.dart
+++ b/lib/date_count_down.dart
@@ -8,22 +8,24 @@ import 'countdown.dart';
 ///CountDownText : A simple text widget that display the countdown timer
 ///based on the dateTime given e.g DateTime.utc(2050)
 class CountDownText extends StatefulWidget {
-  CountDownText(
-      {Key? key,
-      required this.due,
-      required this.finishedText,
-      this.longDateName = false,
-      this.style,
-      this.showLabel = false,
-      this.daysTextLong = " days ",
-      this.hoursTextLong = " hours ",
-      this.minutesTextLong = " minutes ",
-      this.secondsTextLong = " seconds ",
-      this.daysTextShort = " d ",
-      this.hoursTextShort = " h ",
-      this.minutesTextShort = " m ",
-      this.secondsTextShort = " s ",})
-      : super(key: key);
+  CountDownText({
+    Key? key,
+    required this.due,
+    required this.finishedText,
+    this.longDateName = false,
+    this.style,
+    this.showLabel = false,
+    this.collapsing = false,
+    this.daysTextLong = " days ",
+    this.hoursTextLong = " hours ",
+    this.minutesTextLong = " minutes ",
+    this.secondsTextLong = " seconds ",
+    this.daysTextShort = " d ",
+    this.hoursTextShort = " h ",
+    this.minutesTextShort = " m ",
+    this.secondsTextShort = " s ",
+    this.endingText = 'left',
+  }) : super(key: key);
 
   final DateTime? due;
   final String? finishedText;
@@ -38,6 +40,12 @@ class CountDownText extends StatefulWidget {
   final String hoursTextShort;
   final String minutesTextShort;
   final String secondsTextShort;
+
+  /// Makes text to show only the biggest time unit. Starting from days left, then hours etc...
+  final bool collapsing;
+
+  /// Shows in the end of the text when its collapsing
+  final String endingText;
 
   @override
   _CountDownTextState createState() => _CountDownTextState();
@@ -63,17 +71,22 @@ class _CountDownTextState extends State<CountDownText> {
   @override
   Widget build(BuildContext context) {
     return Text(
-      CountDown().timeLeft(widget.due!,
-          widget.finishedText!,
-          widget.daysTextLong,
-          widget.hoursTextLong,
-          widget.minutesTextLong,
-          widget.secondsTextLong,
-          widget.daysTextShort,
-          widget.hoursTextShort,
-          widget.minutesTextShort,
-          widget.secondsTextShort,
-          longDateName: widget.longDateName, showLabel: widget.showLabel),
+      CountDown().timeLeft(
+        widget.due!,
+        widget.finishedText!,
+        widget.daysTextLong,
+        widget.hoursTextLong,
+        widget.minutesTextLong,
+        widget.secondsTextLong,
+        widget.daysTextShort,
+        widget.hoursTextShort,
+        widget.minutesTextShort,
+        widget.secondsTextShort,
+        longDateName: widget.longDateName,
+        showLabel: widget.showLabel,
+        collapsing: widget.collapsing,
+        endingText: widget.endingText,
+      ),
       style: widget.style,
     );
   }


### PR DESCRIPTION
I've changed code a bit to show only the biggest time unit. 

while using this feature, the refresh of the widget can be optimized by calculate when the next setState should be instead of refresing every second.

usage:
CountDownText(
                        due: widget.task.deadlineDate,
                        finishedText: "Expired",
                        showLabel: true,
                        longDateName: true,
                        daysTextLong: " days ",
                        hoursTextLong: " hours ",
                        minutesTextLong: " minutes ",
                        secondsTextLong: " seconds ",
                        collapsing: true,
                        endingText: "left",
                      )


Note : I've also think that I fixed the 00 second 'FinishedText' issue. (Ex: It shows finishedText at 15:23:00)
But DIDN'T TESTED IT.